### PR TITLE
Fix size mismatch error

### DIFF
--- a/train.py
+++ b/train.py
@@ -84,7 +84,8 @@ def render_test(args):
     tensorf = tensorf.to(device)
     tensorf.train()
     tensorf.sampler.update(tensorf.rf, init=True)
-    tensorf.sampler.updateAlphaMask(tensorf.rf, grid_size=[266] * 3)
+    grid_size = ckpt['state_dict']['sampler.alphaMask.alpha_volume'].shape[2:]
+    tensorf.sampler.updateAlphaMask(tensorf.rf, grid_size=grid_size)
     tensorf.load_state_dict(ckpt["state_dict"], strict=False)
     ic(tensorf.sampler.near_far)
     # for i in range(1000):


### PR DESCRIPTION
When evaluating a trained model, there is a mismatch error when in the update of the alphamask of the sampler due to hardcoding to 265. The proposed change reads the grid_size directly from the checkpoint thus fixing this error.